### PR TITLE
Add Cuprite gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,5 +71,5 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "selenium-webdriver"
-
+  gem "cuprite"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,12 +86,20 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.4.0)
       railties (>= 6.0.0)
+    cuprite (0.15)
+      capybara (~> 3.0)
+      ferrum (~> 0.14.0)
     date (3.3.4)
     debug (1.9.1)
       irb (~> 1.10)
       reline (>= 0.3.8)
     diff-lcs (1.5.0)
     erubi (1.12.0)
+    ferrum (0.14)
+      addressable (~> 2.5)
+      concurrent-ruby (~> 1.1)
+      webrick (~> 1.7)
+      websocket-driver (>= 0.6, < 0.8)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.1)
@@ -223,6 +231,7 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webrick (1.8.1)
     websocket (1.2.10)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
@@ -239,6 +248,7 @@ DEPENDENCIES
   bootsnap
   capybara
   cssbundling-rails
+  cuprite
   debug
   jbuilder
   jsbundling-rails

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -34,6 +34,11 @@ RSpec.configure do |config|
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
   config.global_fixtures = :all
 
+  # prevent system tests opening a browser in chrome
+  config.before :all, type: :system do
+    driven_by(:headless_cuprite)
+  end
+
   # config.include ActiveJob::TestHelper
   # config.include ActionMailbox::TestHelper
   # config.include Devise::Test::IntegrationHelpers, type: :feature

--- a/spec/support/cuprite.rb
+++ b/spec/support/cuprite.rb
@@ -1,0 +1,16 @@
+require "capybara/cuprite"
+Capybara.register_driver(:headless_cuprite) do |app|
+  Capybara::Cuprite::Driver.new(
+    app,
+    browser_options: {"disable-smooth-scrolling" => true},
+    headless: !ENV["HEADLESS"].in?(%w[n 0 no false]),
+    inspector: true,
+    process_timeout: 10, # Increase Chrome startup wait time (required for stable CI builds)
+    timeout: 30, # default is 5
+    window_size: [1920, 1080]
+  )
+end
+
+# Configure Capybara to use :cuprite driver by default
+Capybara.default_driver = Capybara.javascript_driver = :headless_cuprite
+Capybara.default_max_wait_time = 30


### PR DESCRIPTION
#### What's this PR do?

Prevents Chrome from opening in the browser during system tests and the following error in
CI:

```
Selenium::WebDriver::Error::SessionNotCreatedError:
            session not created: Chrome failed to start: exited normally.
              (session not created: DevToolsActivePort file doesn't exist)
              (The process started from chrome location
               /usr/bin/google-chrome is no longer running, so ChromeDriver
               is assuming that Chrome has crashed.)
```

The Cuprite gem in Rails is a headless driver for Capybara powered by
PhantomJS. It provides an alternative to using Selenium WebDriver with
Chrome or Firefox, allowing you to run feature/system tests in a headless
manner. Cuprite uses the PhantomJS browser internally, which means it
doesn't require an actual graphical browser window to be opened during
test execution.

#### Background context

Uses CB setup in spec/support file.

#### Learning Resources

- [cuprite gem](
https://github.com/rubycdp/cuprite)

