### PR TITLE
Turbo Drive explainer

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -13,6 +13,7 @@
 @import "components/form";
 @import "components/visually_hidden";
 @import "components/quote";
+// @import "components/turbo_progress_bar";
 
 // Layouts
 @import "layouts/container";

--- a/app/assets/stylesheets/components/_turbo_progress_bar.scss
+++ b/app/assets/stylesheets/components/_turbo_progress_bar.scss
@@ -1,0 +1,3 @@
+.turbo-progress-bar {
+  background: linear-gradient(to right, var(--color-primary), var(--color-primary-rotate));
+}

--- a/app/views/quotes/index.html.erb
+++ b/app/views/quotes/index.html.erb
@@ -3,8 +3,7 @@
     <h1>Quotes</h1>
     <%= link_to "New quote",
                 new_quote_path,
-                class: "btn btn--primary",
-                data: { turbo: false } %>
+                class: "btn btn--primary" %>
   </div>
 
   <%= render @quotes %>

--- a/app/views/quotes/index.html.erb
+++ b/app/views/quotes/index.html.erb
@@ -3,7 +3,8 @@
     <h1>Quotes</h1>
     <%= link_to "New quote",
                 new_quote_path,
-                class: "btn btn--primary" %>
+                class: "btn btn--primary",
+                data: { turbo: false } %>
   </div>
 
   <%= render @quotes %>


### PR DESCRIPTION
## What's this PR do?

Not much... Turbo Drive is already in the app. This is an explainer of how Turbo Drive works

## Background context

Turbo Drive is installed by default in Rails 7 apps. By default, it speeds up the application by turning every link click and form submission into an AJAX request. When it intercepts a link click or form submission, the response to the AJAX request will only replace the `<body>` of the page. By not replacing the `<head>` (in most cases), there is a **considerable performance improvement** because we are not downloading the fonts, CSS and JS files with every request (this happens once when you visit the app for the first time).

### AJAX recap

AJAX (Asynchronous JavaScript and XML) is a technique used in web development to create asynchronous web applications. In Rails, AJAX allows for seamless updates to parts of a webpage without requiring a full page reload, enhancing the user experience by making interactions more responsive and dynamic.

1. Client-Side Trigger

- initiated by user interaction (e.g. submitting a form)

2. Sending an AJAX request

- using `remote: true`. Indicates the request should be handled using AJAX.

```
<%= form_with(model: @post, remote: true) do |form| %>
  <!-- form fields -->
  <%= form.submit %>
<% end %>

<%= link_to 'Delete', post_path(@post), method: :delete, remote: true %>
```

3. Server-side processing

```
def create
  @post = Post.new(post_params)
  if @post.save
    respond_to do |format|
      format.html { redirect_to @post }
      format.js   # renders create.js.erb
    end
  else
    respond_to do |format|
      format.html { render :new }
      format.js   # renders create.js.erb with errors
    end
  end
end
```

4. Responds with JS

- You will see a .js.erb containing JS code to update the page dynamically

```
# app/views/posts/create.js.erb
$("#posts").append("<%= j render @post %>");
$("#new_post")[0].reset();
```

5. Client-side update

- The JS code executed on the client-side manipulates the DOM to update the webpage without a full page reload

### Pseudocode examples for link clicks and form submissions

```
const links = document.querySelectorAll("a");

links.forEach((link) => {
  link.addEventListener("click", (event) => {
    event.preventDefault();
    // Additional AJAX request and response handling logic would go here
  });
});
```

1. Select all links on the page
3. Add a "click" event listener on each link to intercept the click and override the default behavior
4. Override default behavior
5. Convert the click on the link into an AJAX request
6. Replace the current page's `<body>` with the `<body>` of the response and leave the `<head>` unchanged

```
const forms = document.querySelectorAll("form");

forms.forEach((form) => {
  form.addEventListener("submit", (event) => {
    event.preventDefault();
    // Additional AJAX request and response handling logic would go here
  });
});
```

1. Select all forms on the page
2. Add a "submit" event listener on each form to intercept the submission and override the default behavior
3. Override default behavior
4. Convert the form submission into an AJAX request
5. Replace the current page's `<body>` with the `<body>` of the response and leave the `<head>` unchanged
6. When a form is submitted, Turbo Drive intercepts the "submit" event, transforms the submission into an AJAX request and replaces the `<body>` of the page with the `<body>` of the response.

Invalid form submissions have to return a 422 status code for Turbo Drive to replace the `<body>` of the page and display form errors. The alias for the 422 status code in Rails is `status: unprocessable entity`. 

### Disabling Turbo Drive

We can disable turbo using `data: { turbo: false }` - this may be required for gems which do not yet support Turbo Drive.

### The difference between Turbo Drive being disabled and enabled

**With Turbo**

The 'New quote' link only makes three requests to the server, including an AJAX request for the HTML of the Quotes#new page and the favicon (icon displayed in the browser's address bar). 

<img width="234" alt="Screenshot 2024-05-30 at 15 36 10" src="https://github.com/oatkins8/quote-editor/assets/26853094/be93471b-a995-43d4-9d40-04ad6ea5edd9">


**Without turbo**

The 'New quote' link makes several requests including:
- One HTML request to load the Quotes#new HTML page
- One request to load the CSS bundle
- One request to load the JavaScript bundle
- One request to load the favicon of the page

<img width="510" alt="Screenshot 2024-05-30 at 15 33 27" src="https://github.com/oatkins8/quote-editor/assets/26853094/f04855d3-d485-48a0-a00b-c4fd2969f9fa">


The same outcome is true for forms which you can also see demonstrated in the [tutorial](https://www.hotrails.dev/turbo-rails/turbo-drive). 


### data-turbo-track="reload"

In most cases, Turbo Drive only replaces the `<body>` of the page. This would be a problem if we wanted to deploy a change to a file loaded in the `<head>` (e.g. a new CSS file). 

To solve this problem, on every new request, Turbo Drive compares the DOM elements with data-turbo-track="reload" in the <head> of the current HTML page and the <head> of the response. If there are differences, Turbo Drive will **reload the whole page**.

```
    <%# app/views/layouts/application.html.erb %>

    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
    <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
```

## Learning Resources

https://www.hotrails.dev/turbo-rails/turbo-drive
