### PR TITLE
Broadcast quote CRUD to the HTML with Turbo Streams

### DIFF
--- a/app/models/quote.rb
+++ b/app/models/quote.rb
@@ -3,7 +3,7 @@ class Quote < ApplicationRecord
 
   scope :ordered, -> { order(id: :desc) }
 
-  after_create_commit -> { broadcast_prepend_to 'quotes' }
-  after_update_commit -> { broadcast_replace_to 'quotes' }
+  after_create_commit -> { broadcast_prepend_later_to 'quotes' }
+  after_update_commit -> { broadcast_replace_later_to 'quotes' }
   after_destroy_commit -> { broadcast_remove_to 'quotes' }
 end

--- a/app/models/quote.rb
+++ b/app/models/quote.rb
@@ -3,7 +3,9 @@ class Quote < ApplicationRecord
 
   scope :ordered, -> { order(id: :desc) }
 
-  after_create_commit -> { broadcast_prepend_later_to 'quotes' }
-  after_update_commit -> { broadcast_replace_later_to 'quotes' }
-  after_destroy_commit -> { broadcast_remove_to 'quotes' }
+  # after_create_commit -> { broadcast_prepend_later_to 'quotes' }
+  # after_update_commit -> { broadcast_replace_later_to 'quotes' }
+  # after_destroy_commit -> { broadcast_remove_to 'quotes' }
+  # becomes..
+  broadcasts_to ->(quote) { "quotes" }, inserts_by: :prepend
 end

--- a/app/models/quote.rb
+++ b/app/models/quote.rb
@@ -5,4 +5,5 @@ class Quote < ApplicationRecord
 
   after_create_commit -> { broadcast_prepend_to 'quotes' }
   after_update_commit -> { broadcast_replace_to 'quotes' }
+  after_destroy_commit -> { broadcast_remove_to 'quotes' }
 end

--- a/app/models/quote.rb
+++ b/app/models/quote.rb
@@ -3,7 +3,5 @@ class Quote < ApplicationRecord
 
   scope :ordered, -> { order(id: :desc) }
 
-  after_create_commit lambda {
-    broadcast_prepend_to 'quotes', partial: 'quotes/quote', locals: { quote: self }, target: 'quotes'
-  }
+  after_create_commit -> { broadcast_prepend_to 'quotes' }
 end

--- a/app/models/quote.rb
+++ b/app/models/quote.rb
@@ -4,4 +4,5 @@ class Quote < ApplicationRecord
   scope :ordered, -> { order(id: :desc) }
 
   after_create_commit -> { broadcast_prepend_to 'quotes' }
+  after_update_commit -> { broadcast_replace_to 'quotes' }
 end

--- a/app/models/quote.rb
+++ b/app/models/quote.rb
@@ -2,4 +2,8 @@ class Quote < ApplicationRecord
   validates :name, presence: true
 
   scope :ordered, -> { order(id: :desc) }
+
+  after_create_commit lambda {
+    broadcast_prepend_to 'quotes', partial: 'quotes/quote', locals: { quote: self }, target: 'quotes'
+  }
 end

--- a/app/views/quotes/index.html.erb
+++ b/app/views/quotes/index.html.erb
@@ -1,3 +1,5 @@
+<%= turbo_stream_from "quotes" %>
+
 <main class="container">
   <div class="header">
     <h1>Quotes</h1>


### PR DESCRIPTION
## What's this PR do?

Uses Turbo Streams to broadcast quotes' creation, updates and deletion to the HTML. 

## Background context

<img width="673" alt="Screenshot 2024-06-10 at 22 41 14" src="https://github.com/oatkins8/quote-editor/assets/26853094/37e1d818-43ec-4ccf-b59b-d4263981dcc4">

Imagine that someone else creates a quote:

<img width="672" alt="Screenshot 2024-06-10 at 22 42 48" src="https://github.com/oatkins8/quote-editor/assets/26853094/55bbea89-d67b-490a-bab8-7c83b25d0ef8">

We should see:

<img width="671" alt="Screenshot 2024-06-10 at 22 43 45" src="https://github.com/oatkins8/quote-editor/assets/26853094/67f0ea94-976c-43e9-95f5-9ce1cf0c3ddc">


See 1f6f7bc and f2310be for more details on how this works.

## Learning Resources

### [Turbo Frames and Turbo Stream templates](https://www.hotrails.dev/turbo-rails/turbo-frames-and-turbo-streams)

Key learning:
- How to use an after_create_commit to execute a block every time a quote is created
- How to prepend an element with broadcast_prepend_to 
- How to replace an element using broadcast_replace_to
- How to remove an element using broadcast_rmeove_to
- Improving performance with background jobs

Other learning:
- lambda (recap)
    - an anonymous function used to encapsulate behaviour that can be defined,
    stored in a variable and passed around like any other ruby object
    - you call and lambda using the `call` method (e.g. `my_lambda.call(5)`)
    - why would you use a lambda rather than a proc:
    - strict argument checking. ArgumentError raised if the wrong number
    of arguments passed. Helps to catch bugs early.
    - return behaviour. returns control back to the calling method. returning
    from the block should not interfere with the method that invoked the
    callback
